### PR TITLE
oto.comoco.chart-history-v5

### DIFF
--- a/core4/webapps/comoco/src/store/comoco.mutations.js
+++ b/core4/webapps/comoco/src/store/comoco.mutations.js
@@ -17,7 +17,9 @@ const defaultEventObj = createObjectWithDefaultValues(jobTypes, 0)
 const channelDict = {
   'queue': {
     // on_queue:
-    'summary': queueChannelHandler,
+    'summary': queueChannelHandler
+  },
+  'job': {
     // on_event:
     ...eventChannelNames.reduce((computedResult, currentItem) => {
       computedResult[currentItem] = eventChannelHandler


### PR DESCRIPTION
[oto.comoco.chart-history-v5]: fix: add handlers for job channel