### PR TITLE
:new: email sent on creation/password reset: #56

### DIFF
--- a/core4/api/v1/request/role/model.py
+++ b/core4/api/v1/request/role/model.py
@@ -127,12 +127,12 @@ class CoreRole(CoreBase):
         """
         return self.name.lower() < other.name.lower()
 
-    def validate(self):
+    def validate(self, initial=False):
         """
         Ensures users have email *and* password, and all field have the
         expected types and value constraints.
         """
-        self._check_user()
+        self._check_user(initial)
         for field in self.data.values():
             field.validate_type()
             field.validate_value()
@@ -140,13 +140,16 @@ class CoreRole(CoreBase):
     def verify_password(self, plain):
         """
         :param plain: clear text password
-        :return: ``True`` if the role is active and the password matches
+        :return: ``True`` if the role is active , and the password matches
         """
         if self.is_active:
             try:
+                self._check_user()
                 return core4.util.crypt.pwd_context.verify(
                     plain, self.password)
             except ValueError:
+                return False
+            except AttributeError:
                 return False
             except:
                 raise
@@ -161,18 +164,24 @@ class CoreRole(CoreBase):
         has_email = self.email is not None
         return has_email and has_password
 
-    def _check_user(self):
+    def _check_user(self, initial=False):
         """
         :return: verify a valid role (no email and password) or a valid
-                 user role (email and password)
+                 user role (email and password).
+                 When the user is initialy created, he does not need a password
+                 yet. It will be set prior to logging in via a token provided
+                 by email.
         """
         has_password = self.password is not None
         has_email = self.email is not None
-        if ((not (has_password and has_email))
+        if initial:
+            if not (has_email == has_password or has_email):
+                raise AttributeError("user role requires email on creation")
+        elif ((not (has_password and has_email))
                 and (has_password or has_email)):
             raise AttributeError("user role requires email and password")
 
-    async def save(self):
+    async def save(self, initial=False):
         """
         Create or update the role. Please note that a role is only
         materialised, if one or more attributes have changed.
@@ -181,7 +190,7 @@ class CoreRole(CoreBase):
         """
         # await self.create_index()
         await self.resolve_roles()
-        self.validate()
+        self.validate(initial)
         if self._id is None:
             saved = await self._create()
         else:

--- a/core4/api/v1/request/role/template/roles.html
+++ b/core4/api/v1/request/role/template/roles.html
@@ -23,7 +23,7 @@
                         <h1 class="headline mb-3">Roles overview</h1>
                     </v-flex>
                     <v-flex class="text-xs-right">
-                        <v-btn small @click="isCreateDialogOpen=true; currentRole={};" color="primary">
+                        <v-btn small @click="isCreateDialogOpen=true; currentRole={'is_active': true};" color="primary">
                             <v-icon class="mr-1" small>
                                 create
                             </v-icon>

--- a/core4/core4.yaml
+++ b/core4/core4.yaml
@@ -126,6 +126,7 @@ api:
     30: this month
     180: this half-year
     360: this year
+
 email:
   username: ~
   password: ~
@@ -133,6 +134,12 @@ email:
   host: ~
   port: ~
   ssl: ~
+  template:
+    base_dir: email_templates/
+    en:
+      domain: ~
+      password_reset: en/password_reset.txt
+      user_creation: en/user_creation.txt
 
 user_setting:
    _general:

--- a/core4/util/email_templates/en/password_reset.txt
+++ b/core4/util/email_templates/en/password_reset.txt
@@ -1,0 +1,16 @@
+Hello {{ realname }},
+
+you or someone impersonating you requested to reset your password for the user {{ username }}.
+
+If you wish to reset your password, visit the following URL:
+
+{{ domain }}/#/reset/{{ token }}
+
+If you did not request to reset your password, then please contact core operations at {{ contact_email }}.
+
+You can reach our homepage here: {{ domain }}
+
+Thank you for your cooperation.
+
+Your core operators.
+

--- a/core4/util/email_templates/en/user_creation.txt
+++ b/core4/util/email_templates/en/user_creation.txt
@@ -1,0 +1,17 @@
+Hello {{ realname }},
+
+you or someone impersonating you created an account on:
+
+{{ domain }}
+
+Using the username: {{ username }}.
+
+You can set your password here:
+
+{{ domain }}/#/reset/{{ token }}
+
+If you did not create the user yourself, please contact core operations at {{ contact_email }}.
+
+Thank you for your cooperation.
+
+Your core operators.

--- a/tests/api/test_role.py
+++ b/tests/api/test_role.py
@@ -204,12 +204,12 @@ async def test_init(core4api):
     data["passwd"] = "123456"
     rv = await core4api.post("/core4/api/v1/roles", body=data)
     assert rv.json()["code"] == 400
-    assert "requires email and password" in rv.json()["error"]
+    assert "requires email on creation" in rv.json()["error"]
 
     data["realname"] = "Michael Rau"
     rv = await core4api.post("/core4/api/v1/roles", body=data)
     assert rv.json()["code"] == 400
-    assert "requires email and password" in rv.json()["error"]
+    assert "requires email on creation" in rv.json()["error"]
 
     data["email"] = "m.rau-plan-net.com"
     rv = await core4api.post("/core4/api/v1/roles", body=data)


### PR DESCRIPTION
:new: User-creation and requested password-change sends an email to the user (#56).

Users can now be created without a password.

Support jinja for email templates.

Added apropriate tests.

Extended configuration.