### PR TITLE
add check for feather, install if absent

### DIFF
--- a/core4/queue/helper/job/r.py
+++ b/core4/queue/helper/job/r.py
@@ -26,6 +26,9 @@ RLIB = "../lib/R"  # from Python executable
 RLIBVAR = "R_LIBS_SITE"
 
 SNIPPET = """
+if(require('feather')==FALSE){
+    install.packages('feather')
+}
 library(feather)
 
 return <- function(v){


### PR DESCRIPTION
This is with reference to the issue #170 

This piece of code checks if the R package 'feather' is installed on the system running core4.
If not, it installs the package.

Ran into this issue while trying to run a test RJob on staging.