### PR TITLE
change cran mirror

### DIFF
--- a/core4/core4.yaml
+++ b/core4/core4.yaml
@@ -72,7 +72,7 @@ job:
   archive_stamp: "{year:04d}/{month:02d}/{day:02d}/{_id:s}"
 
 rjob:
-  cran_mirror: "http://cran.us.r-project.org"
+  cran_mirror: "https://cloud.r-project.org/"
 
 daemon:
   heartbeat: 15


### PR DESCRIPTION
What is currently set as the CRAN mirror in the yaml (http://cran.us.r-project.org) isn't a valid mirror at all. Ref. list of CRAN mirrors: https://cran.r-project.org/mirrors.html

This will solve issues such as DMC-24 in our Jira.