### PR TITLE
case insensitivity for the email address while resetting password

### DIFF
--- a/core4/api/v1/request/standard/login.py
+++ b/core4/api/v1/request/standard/login.py
@@ -188,6 +188,7 @@ class LoginHandler(CoreRequestHandler):
     async def _start_password_reset(self, email):
         # internal method to create and send the password reset token
         self.logger.debug("enter password reset for [%s]", email)
+        email = re.compile(email, re.IGNORECASE)
         user = await CoreRole().find_one(email=email)
         if user is None:
             self.logger.warning("email [%s] not found", email)


### PR DESCRIPTION
I had missed case insensitivity for the email address while resetting one's password in my last pull req. This fills that gap.