### PR TITLE
fixed passwort reset bug because of regex-email searching

### DIFF
--- a/core4/api/v1/request/standard/login.py
+++ b/core4/api/v1/request/standard/login.py
@@ -188,8 +188,8 @@ class LoginHandler(CoreRequestHandler):
     async def _start_password_reset(self, email):
         # internal method to create and send the password reset token
         self.logger.debug("enter password reset for [%s]", email)
-        email = re.compile(email, re.IGNORECASE)
-        user = await CoreRole().find_one(email=email)
+        regex_email = re.compile(email, re.IGNORECASE)
+        user = await CoreRole().find_one(email=regex_email)
         if user is None:
             self.logger.warning("email [%s] not found", email)
         else:


### PR DESCRIPTION
Because email i overwritten in the old code stand the JWT Token generation is not working anymore. This fix renames the email part for regex searching on the mongo. With this change the passwort reset is working again and not throwing 500 error
